### PR TITLE
Add tests.sh to check the build problems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,16 @@
-/*
-Copyright (c) 2020, Arm Limited and affiliates.
-SPDX-License-Identifier: Apache-2.0
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+# Copyright (c) 2020, Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 FROM golang
 ADD . /go/src/github.com/armPelionEdge/edge-proxy
-RUN go install github.com/armPelionEdge/edge-proxy/cmd/fp-edge
-ENTRYPOINT [ "/go/bin/fp-edge" ]
+RUN go install github.com/armPelionEdge/edge-proxy/cmd/edge-proxy
+ENTRYPOINT [ "/go/bin/edge-proxy" ]

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -1,3 +1,5 @@
+// +build !unit
+
 /*
 Copyright (c) 2020, Arm Limited and affiliates.
 SPDX-License-Identifier: Apache-2.0
@@ -40,7 +42,7 @@ type signResponse struct {
 var _ = Describe("Client", func() {
 	// please make sure to start edge-core locally to make sure the websocket server is running
 	Specify("Make crypto asymmetric call to edge core", func() {
-		client := Dial("/tmp/edge.sock", "/1/pt")
+		client := Dial("/tmp/edge.sock", "/1/pt", func(*Client) error { return nil })
 		defer client.Close()
 
 		var res string

--- a/tests.sh
+++ b/tests.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+echo "Building all go files"
+go build ./...
+echo "Success building all go files"
+
+echo "Running go unit tests"
+go test -tags=unit ./...
+echo "Success running go unit tests"
+
+echo "Building applications"
+go build ./cmd/edge-proxy
+echo "Success building applications"
+
+echo "Building docker images"
+docker build --no-cache . -f Dockerfile
+echo "Success building docker images"


### PR DESCRIPTION
Changes:
* add a test script that could quickly check the go builds and Dockerfile build, and run all the go tests while excluding tests within `rpc` module since it requires edge-core setup
* fix Dockerfile