### PR TITLE
Add CONNECT tunnel over TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Notes
 
 # HTTP(S) Tunnels
 
-Edge-proxy has the option for tunneling traffic over HTTP CONNECT.  This can be done over a TLS connection and/or a non-TLS plain HTTP connection.  At maximum, one plain and one TLS tunnel can be specified.  The following command line options specify the HTTP(S) tunnels.
+Edge-proxy has the option for tunneling traffic over HTTP CONNECT.  This can be done over a TLS connection and/or a non-TLS plain HTTP connection.  At maximum, one plain and one TLS tunnel can be specified.  The following command line options specify the HTTP(S) tunnels.  These options are independent of the `-cert-strategy` and `-cert-strategy-options` options, as they control different proxy services.
 
 ```
   -http-tunnel-listen string

--- a/README.md
+++ b/README.md
@@ -30,3 +30,18 @@ Proxy routing:
 Notes
 - All requests from edge-proxy to the cloud are done over HTTPS
 - The path component of the URL is never changed for a proxied request
+
+# HTTP(S) Tunnels
+
+Edge-proxy has the option for tunneling traffic over HTTP CONNECT.  This can be done over a TLS connection and/or a non-TLS plain HTTP connection.  At maximum, one plain and one TLS tunnel can be specified.  The following command line options specify the HTTP(S) tunnels.
+
+```
+  -http-tunnel-listen string
+    	Listen address for HTTP (CONNECT) tunnel server (default "localhost:8888")
+  -https-tunnel-listen string
+    	Listen address for HTTPS (CONNECT) tunnel server over TLS.  Both tunnels can be served at the same time.
+  -https-tunnel-tls-cert string
+    	For the HTTPS tunnel, specify file name and path to the TLS certificate /path/file.crt
+  -https-tunnel-tls-key string
+    	For the HTTPS tunnel, specify file name and path to the TLS key /path/file.key
+```

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -89,13 +89,6 @@ func main() {
 		}
 	}
 
-	if proxyOnlyMode == false {
-		err := startEdgeProxyReverseTunnel(ca, proxyURI, forwardingAddressesMap, certStrategy, certStrategyOptions)
-		if err != nil {
-			os.Exit(1)
-		}
-	}
-
 	enableHTTPSTunnel := false
 	if httpsTunnelAddr != "" || httpsTunnelTLSCert != "" || httpsTunnelTLSKey != "" {
 		if httpsTunnelAddr == "" {
@@ -115,15 +108,22 @@ func main() {
 		enableHTTPSTunnel = true
 	}
 
+	if proxyOnlyMode == false {
+		err := startEdgeProxyReverseTunnel(ca, proxyURI, forwardingAddressesMap, certStrategy, certStrategyOptions)
+		if err != nil {
+			os.Exit(1)
+		}
+	}
+
 	go func() {
 		server.StartHTTPTunnel(httpTunnelAddr, externalHTTPProxyURI)
 	}()
 
-	go func() {
-		if enableHTTPSTunnel {
+	if enableHTTPSTunnel {
+		go func() {
 			server.StartHTTPSTunnel(httpsTunnelAddr, externalHTTPProxyURI, httpsTunnelTLSCert, httpsTunnelTLSKey)
-		}
-	}()
+		}()
+	}
 
 	ch := make(chan bool)
 	<-ch

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -50,6 +50,8 @@ var certStrategyOptions cmd.OptionMap = cmd.OptionMap{}
 var forwardingAddressesMap string
 var httpTunnelAddr string
 var proxyOnlyMode bool
+var tlsCert string
+var tlsKey string
 
 func main() {
 	flag.StringVar(&tunnelURI, "tunnel-uri", "ws://localhost:8181/connect", "Endpoint to connect to for reverse tunneling")
@@ -62,6 +64,8 @@ func main() {
 	flag.Var(&certStrategyOptions, "cert-strategy-options", "Can be specified one or more times. Must be a key-value pair (<key>=<value>)")
 	flag.StringVar(&forwardingAddressesMap, "forwarding-addresses", "{}", "Map of local address to forwarded address for outgoing HTTP requests. For each forwarding request received at proxy-listen, the destination URI in the request is rewritten based on this map, where the destination server is replaced with the value of the corresponding key.  If the destination server isn't found in this map, then the value of proxy-uri is used.  Must be a json string")
 	flag.StringVar(&httpTunnelAddr, "http-tunnel-listen", "localhost:8888", "Listen address for HTTP (CONNECT) tunnel server")
+	flag.StringVar(&tlsCert, "tls-cert", "", "File name and path to the tls certificate /path/file.crt")
+	flag.StringVar(&tlsKey, "tls-key", "", "File name and path to the tls key /path/file.key")
 	flag.Parse()
 
 	proxyOnlyMode = false
@@ -86,6 +90,20 @@ func main() {
 	if proxyOnlyMode == false {
 		err := startEdgeProxyReverseTunnel(ca, proxyURI, forwardingAddressesMap, certStrategy, certStrategyOptions)
 		if err != nil {
+			os.Exit(1)
+		}
+	}
+
+	if tlsCert != "" {
+		if tlsKey == "" {
+			fmt.Printf("If you provide a TLS Certificate file you must also provide a TLS Key file.\n")
+			os.Exit(1)
+		}
+	}
+
+	if tlsKey != "" {
+		if tlsCert == "" {
+			fmt.Printf("If you provide a TLS Key file you must also provide a TLS Certificate file.\n")
 			os.Exit(1)
 		}
 	}

--- a/server/http_tunnel.go
+++ b/server/http_tunnel.go
@@ -18,7 +18,11 @@ import (
 
 // StartHTTPTunnel starts a server that accepts to the HTTP CONNECT method to proxy arbitrary TCP connections.
 // It can be used to tunnel HTTPS connections.
-func StartHTTPTunnel(addr string, externalProxy string) {
+func StartHTTPTunnel(addr, externalProxy string) {
+	StartHTTPSTunnel(addr, externalProxy, "", "")
+}
+
+func StartHTTPSTunnel(addr, externalProxy, certFile, KeyFile string) {
 	log.Printf("Starting HTTPS proxy on %s\n", addr)
 	proxy := goproxy.NewProxyHttpServer()
 
@@ -35,5 +39,9 @@ func StartHTTPTunnel(addr string, externalProxy string) {
 			return r, nil
 		})
 
-	http.ListenAndServe(addr, proxy)
+	if certFile == "" || KeyFile == "" {
+		http.ListenAndServe(addr, proxy)
+	} else {
+		http.ListenAndServeTLS(addr, certFile, KeyFile, proxy)
+	}
 }

--- a/server/http_tunnel.go
+++ b/server/http_tunnel.go
@@ -23,7 +23,6 @@ func StartHTTPTunnel(addr, externalProxy string) {
 }
 
 func StartHTTPSTunnel(addr, externalProxy, certFile, KeyFile string) {
-	log.Printf("Starting HTTPS proxy on %s\n", addr)
 	proxy := goproxy.NewProxyHttpServer()
 
 	if externalProxy != "" {
@@ -40,13 +39,13 @@ func StartHTTPSTunnel(addr, externalProxy, certFile, KeyFile string) {
 		})
 
 	if certFile == "" || KeyFile == "" {
-		log.Printf("HTTP Tunnel: not using TLS\n")
+		log.Printf("HTTP Tunnel: starting a plain HTTP tunnel on %s\n", addr)
 		err := http.ListenAndServe(addr, proxy)
 		if err != nil {
 			log.Printf("HTTP Tunnel encountered an error while starting: %s\n", err.Error())
 		}
 	} else {
-		log.Printf("HTTP Tunnel: using TLS\n")
+		log.Printf("HTTP Tunnel: starting HTTP tunnel over TLS on %s\n", addr)
 		err := http.ListenAndServeTLS(addr, certFile, KeyFile, proxy)
 		if err != nil {
 			log.Printf("HTTP Tunnel over TLS encountered an error while starting: %s\n", err.Error())

--- a/server/http_tunnel.go
+++ b/server/http_tunnel.go
@@ -40,8 +40,16 @@ func StartHTTPSTunnel(addr, externalProxy, certFile, KeyFile string) {
 		})
 
 	if certFile == "" || KeyFile == "" {
-		http.ListenAndServe(addr, proxy)
+		log.Printf("HTTP Tunnel: not using TLS\n")
+		err := http.ListenAndServe(addr, proxy)
+		if err != nil {
+			log.Printf("HTTP Tunnel encountered an error while starting: %s\n", err.Error())
+		}
 	} else {
-		http.ListenAndServeTLS(addr, certFile, KeyFile, proxy)
+		log.Printf("HTTP Tunnel: using TLS\n")
+		err := http.ListenAndServeTLS(addr, certFile, KeyFile, proxy)
+		if err != nil {
+			log.Printf("HTTP Tunnel over TLS encountered an error while starting: %s\n", err.Error())
+		}
 	}
 }


### PR DESCRIPTION
These commits will be squashed and merged as one commit.

Commit message:

Add the option to run a CONNECT tunnel over TLS.  This tunnel will run alongside the CONNECT tunnel over plain HTTP, in order to allow internal services (e.g. edge-core) to connect without encryption, and external services to connect with encryption.  In order to run the new tunnel, specify the listening address, server cert and key.