### PR TITLE
Add basic auth support for HTTPS tunnel

### DIFF
--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -96,20 +96,31 @@ func main() {
 	enableHTTPSTunnel := false
 	if httpsTunnelAddr != "" || httpsTunnelTLSCert != "" || httpsTunnelTLSKey != "" {
 		if httpsTunnelAddr == "" {
-			fmt.Printf("You must also provide a tunnel address in order to enable the HTTPS tunnel.\n")
+			fmt.Printf("Error: you must also provide a tunnel address in order to enable the HTTPS tunnel.\n")
 			os.Exit(1)
 		}
 
 		if httpsTunnelTLSCert == "" {
-			fmt.Printf("You must also provide a TLS cert file in order to enable the HTTPS tunnel.\n")
+			fmt.Printf("Error: you must also provide a TLS cert file in order to enable the HTTPS tunnel.\n")
 			os.Exit(1)
 		}
 
 		if httpsTunnelTLSKey == "" {
-			fmt.Printf("You must also provide a TLS key file in order to enable the HTTPS tunnel.\n")
+			fmt.Printf("Error: you must also provide a TLS key file in order to enable the HTTPS tunnel.\n")
 			os.Exit(1)
 		}
 		enableHTTPSTunnel = true
+	}
+
+	// XOR
+	if (httpsTunnelUsername == "") != (httpsTunnelPassword == "") {
+		fmt.Printf("Error: you must specify both the HTTPS tunnel username and password, or neither.\n")
+		os.Exit(1)
+	}
+
+	if httpsTunnelUsername != "" && !enableHTTPSTunnel {
+		fmt.Printf("Error: you specified a username and password for the HTTPS tunnel.  You must also specify a listening address, TLS cert and TLS key to enable the HTTPS tunnel.")
+		os.Exit(1)
 	}
 
 	if proxyOnlyMode == false {

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -53,6 +53,8 @@ var proxyOnlyMode bool
 var httpsTunnelAddr string
 var httpsTunnelTLSCert string
 var httpsTunnelTLSKey string
+var httpsTunnelUsername string
+var httpsTunnelPassword string
 
 func main() {
 	flag.StringVar(&tunnelURI, "tunnel-uri", "ws://localhost:8181/connect", "Endpoint to connect to for reverse tunneling")
@@ -68,6 +70,8 @@ func main() {
 	flag.StringVar(&httpsTunnelAddr, "https-tunnel-listen", "", "Listen address for HTTPS (CONNECT) tunnel server over TLS.  Both tunnels can be served at the same time.")
 	flag.StringVar(&httpsTunnelTLSCert, "https-tunnel-tls-cert", "", "For the HTTPS tunnel, specify file name and path to the TLS certificate /path/file.crt")
 	flag.StringVar(&httpsTunnelTLSKey, "https-tunnel-tls-key", "", "For the HTTPS tunnel, specify file name and path to the TLS key /path/file.key")
+	flag.StringVar(&httpsTunnelUsername, "https-tunnel-username", "", "For the HTTPS tunnel only, require this username for basic authentication")
+	flag.StringVar(&httpsTunnelPassword, "https-tunnel-password", "", "For the HTTPS tunnel only, require this password for basic authentication")
 	flag.Parse()
 
 	proxyOnlyMode = false
@@ -121,7 +125,7 @@ func main() {
 
 	if enableHTTPSTunnel {
 		go func() {
-			server.StartHTTPSTunnel(httpsTunnelAddr, externalHTTPProxyURI, httpsTunnelTLSCert, httpsTunnelTLSKey)
+			server.StartHTTPSTunnel(httpsTunnelAddr, externalHTTPProxyURI, httpsTunnelTLSCert, httpsTunnelTLSKey, httpsTunnelUsername, httpsTunnelPassword)
 		}()
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/PelionIoT/remotedialer v1.0.0
 	github.com/elazarl/goproxy v0.0.0-20210110162100-a92cc753f88e
+	github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 // indirect
 	github.com/gorilla/websocket v1.4.2
 	github.com/onsi/ginkgo v1.12.3
 	github.com/onsi/gomega v1.10.1

--- a/server/http_tunnel.go
+++ b/server/http_tunnel.go
@@ -48,7 +48,7 @@ func StartHTTPSTunnel(addr, externalProxy, certFile, keyFile, username, password
 	if username != "" || password != "" {
 		auth.ProxyBasic(proxy, "tunnel", func(user, passwd string) bool {
 			authorized := (user == username && passwd == password)
-			log.Printf("HTTP Tunnel: user=%s, password=%s, authorized=%t\n", user, password, authorized)
+			log.Printf("HTTP Tunnel: user=%s, password=%s, authorized=%t\n", user, passwd, authorized)
 			return authorized
 		})
 	}

--- a/server/http_tunnel.go
+++ b/server/http_tunnel.go
@@ -48,7 +48,7 @@ func StartHTTPSTunnel(addr, externalProxy, certFile, keyFile, username, password
 	if username != "" || password != "" {
 		auth.ProxyBasic(proxy, "tunnel", func(user, passwd string) bool {
 			authorized := (user == username && passwd == password)
-			log.Printf("HTTP Tunnel: user=%s, password=%s, authorized=%t\n", user, passwd, authorized)
+			log.Printf("HTTP Tunnel: authorized=%t\n", authorized)
 			return authorized
 		})
 	}


### PR DESCRIPTION
-Accept username and password from command line
-Authorize requests based on username and password.
-The above only applies to the CONNECT tunnel over TLS