### PR TITLE
Handle HTTP(S) tunnel errors

### DIFF
--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -131,12 +131,18 @@ func main() {
 	}
 
 	go func() {
-		server.StartHTTPTunnel(httpTunnelAddr, externalHTTPProxyURI)
+		err := server.StartHTTPTunnel(httpTunnelAddr, externalHTTPProxyURI)
+		if err != nil {
+			os.Exit(1)
+		}
 	}()
 
 	if enableHTTPSTunnel {
 		go func() {
-			server.StartHTTPSTunnel(httpsTunnelAddr, externalHTTPProxyURI, httpsTunnelTLSCert, httpsTunnelTLSKey, httpsTunnelUsername, httpsTunnelPassword)
+			err := server.StartHTTPSTunnel(httpsTunnelAddr, externalHTTPProxyURI, httpsTunnelTLSCert, httpsTunnelTLSKey, httpsTunnelUsername, httpsTunnelPassword)
+			if err != nil {
+				os.Exit(1)
+			}
 		}()
 	}
 

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -133,6 +133,7 @@ func main() {
 	go func() {
 		err := server.StartHTTPTunnel(httpTunnelAddr, externalHTTPProxyURI)
 		if err != nil {
+			fmt.Printf("Error encountered while starting HTTP tunnel: %s, quitting.\n", err.Error())
 			os.Exit(1)
 		}
 	}()
@@ -141,6 +142,7 @@ func main() {
 		go func() {
 			err := server.StartHTTPSTunnel(httpsTunnelAddr, externalHTTPProxyURI, httpsTunnelTLSCert, httpsTunnelTLSKey, httpsTunnelUsername, httpsTunnelPassword)
 			if err != nil {
+				fmt.Printf("Error encountered while starting HTTPS tunnel: %s, quitting.\n", err.Error())
 				os.Exit(1)
 			}
 		}()

--- a/server/http_tunnel.go
+++ b/server/http_tunnel.go
@@ -21,18 +21,18 @@ import (
 
 // StartHTTPTunnel starts a server that accepts to the HTTP CONNECT method to proxy arbitrary TCP connections.
 // It can be used to tunnel HTTPS connections.
-func StartHTTPTunnel(addr, externalProxy string) {
-	StartHTTPSTunnel(addr, externalProxy, "", "", "", "")
+func StartHTTPTunnel(addr, externalProxy string) error {
+	return StartHTTPSTunnel(addr, externalProxy, "", "", "", "")
 }
 
-func StartHTTPSTunnel(addr, externalProxy, certFile, keyFile, username, password string) {
+func StartHTTPSTunnel(addr, externalProxy, certFile, keyFile, username, password string) error {
 	proxy := goproxy.NewProxyHttpServer()
 
 	if externalProxy != "" {
 		u, err := url.Parse(externalProxy)
 		if err != nil {
 			log.Printf("HTTP(S) Tunnel: failed to parse external proxy: %s\n", err.Error())
-			return
+			return err
 		}
 		proxy.Tr = &http.Transport{
 			Proxy: func(req *http.Request) (*url.URL, error) {
@@ -75,12 +75,17 @@ func StartHTTPSTunnel(addr, externalProxy, certFile, keyFile, username, password
 		err := http.ListenAndServe(addr, proxy)
 		if err != nil {
 			log.Printf("HTTP Tunnel encountered an error while starting: %s\n", err.Error())
+			return err
 		}
 	} else {
 		log.Printf("HTTP Tunnel: starting HTTP tunnel over TLS on %s\n", addr)
 		err := http.ListenAndServeTLS(addr, certFile, keyFile, proxy)
 		if err != nil {
 			log.Printf("HTTP Tunnel over TLS encountered an error while starting: %s\n", err.Error())
+			return err
 		}
 	}
+
+	// Should not get here
+	return nil
 }


### PR DESCRIPTION
Propagate HTTP(S) tunnel errors to main.go, and exit if an error is
encountered.  This fixes the issue where a tunnel can quit but leave the
rest of edge-proxy running.