### PR TITLE
Add proxy CACert option

### DIFF
--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -139,7 +139,11 @@ func main() {
 	}
 
 	go func() {
-		err := server.StartHTTPTunnel(httpTunnelAddr, externalHTTPProxyURI, externalHTTPProxyCACert)
+		err := server.StartHTTPTunnel(&server.HTTPTunnelConfig{
+			Addr:          httpTunnelAddr,
+			ExternalProxy: externalHTTPProxyURI,
+			RootCAFile:    externalHTTPProxyCACert,
+		})
 		if err != nil {
 			fmt.Printf("Error encountered while starting HTTP tunnel: %s, quitting.\n", err.Error())
 			os.Exit(1)
@@ -148,7 +152,15 @@ func main() {
 
 	if enableHTTPSTunnel {
 		go func() {
-			err := server.StartHTTPSTunnel(httpsTunnelAddr, externalHTTPProxyURI, externalHTTPProxyCACert, httpsTunnelTLSCert, httpsTunnelTLSKey, httpsTunnelUsername, httpsTunnelPassword)
+			err := server.StartHTTPSTunnel(&server.HTTPSTunnelConfig{
+				Addr:          httpsTunnelAddr,
+				ExternalProxy: externalHTTPProxyURI,
+				RootCAFile:    externalHTTPProxyCACert,
+				CertFile:      httpsTunnelTLSCert,
+				KeyFile:       httpsTunnelTLSKey,
+				Username:      httpsTunnelUsername,
+				Password:      httpsTunnelPassword,
+			})
 			if err != nil {
 				fmt.Printf("Error encountered while starting HTTPS tunnel: %s, quitting.\n", err.Error())
 				os.Exit(1)

--- a/server/http_tunnel.go
+++ b/server/http_tunnel.go
@@ -22,17 +22,37 @@ import (
  * would be easier to have edge-proxy handle tunneling configuration in one place.
  */
 
-// StartHTTPTunnel starts a server that accepts to the HTTP CONNECT method to proxy arbitrary TCP connections.
-// It can be used to tunnel HTTPS connections.
-func StartHTTPTunnel(addr, externalProxy string, rootCAFile string) error {
-	return StartHTTPSTunnel(addr, externalProxy, rootCAFile, "", "", "", "")
+type HTTPTunnelConfig struct {
+	Addr          string
+	ExternalProxy string
+	RootCAFile    string
 }
 
-func StartHTTPSTunnel(addr, externalProxy, rootCAFile, certFile, keyFile, username, password string) error {
+// StartHTTPTunnel starts a server that accepts to the HTTP CONNECT method to proxy arbitrary TCP connections.
+// It can be used to tunnel HTTPS connections.
+func StartHTTPTunnel(config *HTTPTunnelConfig) error {
+	return StartHTTPSTunnel(&HTTPSTunnelConfig{
+		Addr:          config.Addr,
+		ExternalProxy: config.ExternalProxy,
+		RootCAFile:    config.RootCAFile,
+	})
+}
+
+type HTTPSTunnelConfig struct {
+	Addr          string
+	ExternalProxy string
+	RootCAFile    string
+	CertFile      string
+	KeyFile       string
+	Username      string
+	Password      string
+}
+
+func StartHTTPSTunnel(config *HTTPSTunnelConfig) error {
 	proxy := goproxy.NewProxyHttpServer()
 
-	if externalProxy != "" {
-		u, err := url.Parse(externalProxy)
+	if config.ExternalProxy != "" {
+		u, err := url.Parse(config.ExternalProxy)
 		if err != nil {
 			log.Printf("HTTP(S) Tunnel: failed to parse external proxy: %s\n", err.Error())
 			return err
@@ -45,9 +65,9 @@ func StartHTTPSTunnel(addr, externalProxy, rootCAFile, certFile, keyFile, userna
 				ServerName: u.Hostname(),
 			},
 		}
-		if rootCAFile != "" {
+		if config.RootCAFile != "" {
 			// Use user defined root CA
-			certs, err := ioutil.ReadFile(rootCAFile)
+			certs, err := ioutil.ReadFile(config.RootCAFile)
 			if err != nil {
 				log.Printf("HTTP(S) Tunnel: failed to read root CA file: %s\n", err.Error())
 				return err
@@ -56,13 +76,13 @@ func StartHTTPSTunnel(addr, externalProxy, rootCAFile, certFile, keyFile, userna
 			rootCAPool := x509.NewCertPool()
 			ok := rootCAPool.AppendCertsFromPEM(certs)
 			if !ok {
-				log.Printf("HTTP(S) Tunnel: failed to parse root CA file: %s\n", rootCAFile)
+				log.Printf("HTTP(S) Tunnel: failed to parse root CA file: %s\n", config.RootCAFile)
 				return errors.New("Failed to parse root CA certificate file.")
 			}
 
 			proxy.Tr.TLSClientConfig.RootCAs = rootCAPool
 		}
-		proxy.ConnectDial = proxy.NewConnectDialToProxyWithHandler(externalProxy, func(req *http.Request) {
+		proxy.ConnectDial = proxy.NewConnectDialToProxyWithHandler(config.ExternalProxy, func(req *http.Request) {
 			if u.User != nil {
 				credentials := base64.StdEncoding.EncodeToString([]byte(u.User.String()))
 				req.Header.Add("Proxy-Authorization", "Basic "+credentials)
@@ -82,24 +102,24 @@ func StartHTTPSTunnel(addr, externalProxy, rootCAFile, certFile, keyFile, userna
 			return r, nil
 		})
 
-	if username != "" || password != "" {
+	if config.Username != "" || config.Password != "" {
 		auth.ProxyBasic(proxy, "tunnel", func(user, passwd string) bool {
-			authorized := (user == username && passwd == password)
+			authorized := (user == config.Username && passwd == config.Password)
 			log.Printf("HTTP Tunnel: authorized=%t\n", authorized)
 			return authorized
 		})
 	}
 
-	if certFile == "" || keyFile == "" {
-		log.Printf("HTTP Tunnel: starting a plain HTTP tunnel on %s\n", addr)
-		err := http.ListenAndServe(addr, proxy)
+	if config.CertFile == "" || config.KeyFile == "" {
+		log.Printf("HTTP Tunnel: starting a plain HTTP tunnel on %s\n", config.Addr)
+		err := http.ListenAndServe(config.Addr, proxy)
 		if err != nil {
 			log.Printf("HTTP Tunnel encountered an error while starting: %s\n", err.Error())
 			return err
 		}
 	} else {
-		log.Printf("HTTP Tunnel: starting HTTP tunnel over TLS on %s\n", addr)
-		err := http.ListenAndServeTLS(addr, certFile, keyFile, proxy)
+		log.Printf("HTTP Tunnel: starting HTTP tunnel over TLS on %s\n", config.Addr)
+		err := http.ListenAndServeTLS(config.Addr, config.CertFile, config.KeyFile, proxy)
 		if err != nil {
 			log.Printf("HTTP Tunnel over TLS encountered an error while starting: %s\n", err.Error())
 			return err


### PR DESCRIPTION
Use the option -external-http-proxy-cacert to specify a root CA for
external proxy.  This is useful when the user can't or doesn't want to
modify the system root trust settings.