### PR TITLE
Websocket Tunnel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/PelionIoT/remotedialer v1.0.0
 	github.com/elazarl/goproxy v0.0.0-20210110162100-a92cc753f88e
-	github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 // indirect
+	github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2
 	github.com/gorilla/websocket v1.4.2
 	github.com/onsi/ginkgo v1.12.3
 	github.com/onsi/gomega v1.10.1

--- a/server/ws_tunnel.go
+++ b/server/ws_tunnel.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"errors"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+
+	"github.com/elazarl/goproxy"
+)
+
+/*
+ * The purpose of this feature is  to allow tunneling of arbitrary TCP connections using the wstunnel protocol.
+ * One use case for this is to allow tunneling of all Pelion edge traffic so through a restrictive corporate firewall.
+ */
+
+type WSTunnelConfig struct {
+	ListenAddr string // Address of the listening port
+	TunnelAddr string // Address of the remote wsTunnel server
+}
+
+// StartWSTunnel starts a server that accepts HTTP CONNECT method to proxy arbitrary TCP connections.
+//
+func StartWSTunnel(config *WSTunnelConfig) error {
+	proxy := goproxy.NewProxyHttpServer()
+
+	_, err := url.Parse(config.TunnelAddr)
+	if err != nil {
+		log.Printf("HTTP(S) Tunnel: failed to parse external proxy: %s\n", err.Error())
+		return err
+	}
+	proxy.Tr = &http.Transport{
+		// Configuration for non-CONNECT requests
+		Proxy: func(req *http.Request) (*url.URL, error) {
+			return nil, errors.New("This proxy can only handle CONNECT requests.")
+		},
+	}
+	proxy.ConnectDial = func(network string, addr string) (net.Conn, error) {
+		// TODO: handle connecting to a new address
+		// network: "tcp", maybe "tcp6"
+		// addr: a URL, something like "https://www.example.com"
+		return nil, errors.New("Not implemented.")
+	}
+
+	proxy.OnRequest().HandleConnectFunc(func(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
+		log.Printf("WebSocket Tunnel: got CONNECT request %s\n", host)
+		return nil, host
+	})
+
+	proxy.OnRequest().DoFunc(
+		func(r *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+			// Leave the request untouched.  Log a message for debugging purposes.
+			log.Printf("HTTP Tunnel: got request %s\n", r.URL)
+			return r, nil
+		})
+
+	log.Printf("WS Tunnel: starting on %s\n", config.ListenAddr)
+	err = http.ListenAndServe(config.ListenAddr, proxy)
+	if err != nil {
+		log.Printf("WS Tunnel encountered an error while starting: %s\n", err.Error())
+		return err
+	}
+
+	// Should not get here
+	return nil
+}


### PR DESCRIPTION
Add a new proxy class to edge-proxy.  The intended purpose is to listen on HTTP CONNECT and be a wstunnel client, in order to tunnel arbitrary TCP connections.