### PR TITLE
go vet & golint fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,8 @@ jobs:
           git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github".insteadOf "https://github"
       - run: git clone git@github.com:PelionIoT/scripts-internal.git
       - run: ls -al
-      - name: Run go vet (findings may not increase)
-        run: scripts-internal/ci/more-lines-checker.sh ${{ github.event.repository.default_branch }} ${{ github.ref_name }} "scripts-internal/golang/go_vet_script.sh --all"
+      - name: Run go vet
+        run: scripts-internal/golang/go_vet_script.sh --all
 
   golint-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build all
         run: scripts-internal/golang/go_build_script.sh --all
 
-  go-vet:
+  go-vet-and-lint:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -37,28 +37,12 @@ jobs:
         run: | 
           git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github.com/".insteadOf "git@github.com:"
           git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github".insteadOf "https://github"
+      - run: sudo apt install golint
       - run: git clone git@github.com:PelionIoT/scripts-internal.git
-      - run: ls -al
       - name: Run go vet
         run: scripts-internal/golang/go_vet_script.sh --all
-
-  golint-check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Set up golang
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.18'
-      - name: Set GitHub access token via git config
-        run: | 
-          git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github.com/".insteadOf "git@github.com:"
-          git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github".insteadOf "https://github"
-      - run: git clone git@github.com:PelionIoT/scripts-internal.git
-      - run: ls -al
-      - name: Run golint-checker (findings may not increase)
-        run: scripts-internal/ci/more-lines-checker.sh ${{ github.event.repository.default_branch }} ${{ github.ref_name }} "scripts-internal/golang/golint_script.sh --all"
+      - name: Run go lint
+        run: "scripts-internal/golang/golint_script.sh --all"
 
   go-rpc-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,24 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-all:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Set up golang
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.18'
-      - name: Set GitHub access token via git config
-        run: | 
-          git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github.com/".insteadOf "git@github.com:"
-          git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github".insteadOf "https://github"
-      - run: git clone git@github.com:PelionIoT/scripts-internal.git
-      - name: Build all
-        run: scripts-internal/golang/go_build_script.sh --all
-
-  go-vet-and-lint:
+  go-build-and-checks:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -39,10 +22,17 @@ jobs:
           git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github".insteadOf "https://github"
       - run: sudo apt install golint
       - run: git clone git@github.com:PelionIoT/scripts-internal.git
+      - name: Build all
+        run: scripts-internal/golang/go_build_script.sh --all
       - name: Run go vet
         run: scripts-internal/golang/go_vet_script.sh --all
       - name: Run go lint
         run: "scripts-internal/golang/golint_script.sh --all"
+      - name: Run pysh-check
+        run: |
+           sudo apt install pycodestyle pydocstyle black
+           echo "." >scripts-internal/.nopyshcheck
+           scripts-internal/pysh-check/pysh-check.sh --workdir .
 
   go-rpc-test:
     runs-on: ubuntu-latest
@@ -89,18 +79,3 @@ jobs:
           kill $edgepid
           echo Delete $devid via Izuma V3 REST API
           scripts-internal/cloud/delete-device.sh $devid ${{ secrets.EDGE_PROXY_CI_CLOUD_ACCESS__KEY }}
-
-  run-pysh-check:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-      # Install pyshcheck tooling
-      - run: sudo apt install pycodestyle pydocstyle black
-      # git instead of rules to use access token
-      - run: git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github.com/".insteadOf "git@github.com:"
-      - run: git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github".insteadOf "https://github"
-      # Linux coreutils is already installed wc -command can be found.
-      - run: git clone git@github.com:PelionIoT/scripts-internal.git
-      #- run: git clone https://github.com/PelionIoT/scripts-internal.git
-      - run: echo "." >scripts-internal/.nopyshcheck
-      - run: scripts-internal/pysh-check/pysh-check.sh --workdir .

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,3 @@
 # Backup files
 *.tmp
 *.$$$
-
-# Edge-proxy binary itself
-edge-proxy
-

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -1,5 +1,7 @@
 /*
 Copyright (c) 2020, Arm Limited and affiliates.
+Copyright (c) 2023, Izuma Networks
+
 SPDX-License-Identifier: Apache-2.0
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -37,7 +39,10 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+// TunnelBackoffSeconds defines the retry time for TLS
 const TunnelBackoffSeconds = 10
+
+// ServerBackoffSeconds defines the retry time proxy server
 const ServerBackoffSeconds = 10
 
 var tunnelURI string

--- a/cmd/option_map.go
+++ b/cmd/option_map.go
@@ -1,5 +1,7 @@
 /*
 Copyright (c) 2020, Arm Limited and affiliates.
+Copyright (c) 2023, Izuma Networks
+
 SPDX-License-Identifier: Apache-2.0
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -11,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package cmd - storing key/value pairs in OptionMap
 package cmd
 
 import (
@@ -18,6 +22,7 @@ import (
 	"strings"
 )
 
+// OptionMap for storing string/string key-value pairs (cmd-module)
 type OptionMap map[string]string
 
 func (m *OptionMap) String() string {
@@ -28,6 +33,7 @@ func (m *OptionMap) String() string {
 	return fmt.Sprintf("%v", *m)
 }
 
+// Set -function for storing string/string key-value pairs to OptionMap
 func (m *OptionMap) Set(value string) error {
 	parts := strings.SplitN(value, "=", 2)
 

--- a/http/handler.go
+++ b/http/handler.go
@@ -1,5 +1,7 @@
 /*
 Copyright (c) 2020, Arm Limited and affiliates.
+Copyright (c) 2023, Izuma Networks
+
 SPDX-License-Identifier: Apache-2.0
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,6 +24,7 @@ import (
 	"net/url"
 )
 
+// EdgeHTTPProxy starts serving the proxy requests via proxyForEdge (http.request).
 func EdgeHTTPProxy(forwardingAddress func(string) string, caList *x509.CertPool, clientCert *tls.Certificate, proxyForEdge func(*http.Request) (*url.URL, error)) http.Handler {
 	proxy := SmartHTTPProxy(forwardingAddress, caList, clientCert, proxyForEdge)
 

--- a/http/smart_proxy.go
+++ b/http/smart_proxy.go
@@ -1,5 +1,7 @@
 /*
 Copyright (c) 2020, Arm Limited and affiliates.
+Copyright (c) 2023, Izuma Networks
+
 SPDX-License-Identifier: Apache-2.0
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -27,11 +29,13 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+// SmartProxy - stores http and websocket handlers
 type SmartProxy struct {
 	httpHandler http.Handler
 	wsHandler   http.Handler
 }
 
+// SmartHTTPProxy function for proxying the connections (http and websocket)
 func SmartHTTPProxy(forwardingAddress func(string) string, caList *x509.CertPool, clientCert *tls.Certificate, proxyForEdge func(*http.Request) (*url.URL, error)) *SmartProxy {
 	proxyURL := &url.URL{
 		Scheme: "https",
@@ -82,6 +86,7 @@ func isWebsocketRequest(r *http.Request) bool {
 	return strings.ToLower(r.Header.Get("Connection")) == "upgrade" && strings.ToLower(r.Header.Get("Upgrade")) == "websocket"
 }
 
+// WebsocketProxyHandler - keeps track of websocket prooxy details
 type WebsocketProxyHandler struct {
 	Dialer            *websocket.Dialer
 	ProxyURL          *url.URL

--- a/http/transport.go
+++ b/http/transport.go
@@ -1,5 +1,7 @@
 /*
 Copyright (c) 2020, Arm Limited and affiliates.
+Copyright (c) 2023, Izuma Networks
+
 SPDX-License-Identifier: Apache-2.0
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -54,6 +56,7 @@ func splitAddr(host string) (string, string, int, error) {
 	return hostParts[0], hostParts[1], port, nil
 }
 
+// EdgeTransport - transport layer for the edge-proxy
 func EdgeTransport(caList *x509.CertPool, clientCert *tls.Certificate, proxyForEdge func(*http.Request) (*url.URL, error)) *http.Transport {
 	t := &http.Transport{
 		Proxy: proxyForEdge,

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -1,5 +1,7 @@
 /*
 Copyright (c) 2020, Arm Limited and affiliates.
+Copyright (c) 2023, Izuma Networks
+
 SPDX-License-Identifier: Apache-2.0
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -211,6 +213,7 @@ func (c *Client) run(ctx context.Context) {
 
 		// creates a child context to operate the dispatch() loop
 		childCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		go c.dispatch(childCtx, conn)
 
 		if c.onConn != nil {

--- a/server/edge_http_proxy.go
+++ b/server/edge_http_proxy.go
@@ -1,5 +1,7 @@
 /*
 Copyright (c) 2020, Arm Limited and affiliates.
+Copyright (c) 2023, Izuma Networks
+
 SPDX-License-Identifier: Apache-2.0
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -28,7 +30,8 @@ import (
 	fog_http "github.com/PelionIoT/edge-proxy/http"
 )
 
-func RunEdgeHTTPProxyServer(ctx context.Context, listenAddr string, forwardingAddress func(string) string, caList *x509.CertPool, clientCert *tls.Certificate, proxyForEdge func(* http.Request) (*url.URL, error)) {
+// RunEdgeHTTPProxyServer - run HTTP proxy server for Edge
+func RunEdgeHTTPProxyServer(ctx context.Context, listenAddr string, forwardingAddress func(string) string, caList *x509.CertPool, clientCert *tls.Certificate, proxyForEdge func(*http.Request) (*url.URL, error)) {
 	handler := fog_http.EdgeHTTPProxy(forwardingAddress, caList, clientCert, proxyForEdge)
 	listener, err := net.Listen("tcp", listenAddr)
 
@@ -59,6 +62,7 @@ func RunEdgeHTTPProxyServer(ctx context.Context, listenAddr string, forwardingAd
 	fmt.Printf("HTTP edge proxy server shut down with error: %s\n", err.Error())
 }
 
+// RunEdgeTLSProxyServer - run TLS proxy server for Edge
 func RunEdgeTLSProxyServer(ctx context.Context, listenAddr string, cloudURL *url.URL, caList *x509.CertPool, clientCert *tls.Certificate) {
 	host := host(cloudURL)
 	listener, err := net.Listen("tcp", listenAddr)

--- a/server/http_tunnel.go
+++ b/server/http_tunnel.go
@@ -1,3 +1,19 @@
+/*
+Copyright (c) 2020, Arm Limited and affiliates.
+Copyright (c) 2023, Izuma Networks
+
+SPDX-License-Identifier: Apache-2.0
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package server
 
 import (
@@ -16,12 +32,13 @@ import (
 
 /*
  * The purpose of this feature is  to allow tunneling of arbitrary HTTP(S) connections.
- * One use case for this is to allow tunneling of all Pelion edge traffic over an authenticated
+ * One use case for this is to allow tunneling of all Izuma edge traffic over an authenticated
  * proxy, so that we can function behind restrictive firewalls that only allow HTTP(S)
  * traffic to pass through them.  As opposed to adding tuneling code to each service, it
  * would be easier to have edge-proxy handle tunneling configuration in one place.
  */
 
+// HTTPTunnelConfig for keeping track of HTTP connection details
 type HTTPTunnelConfig struct {
 	Addr          string
 	ExternalProxy string
@@ -38,6 +55,7 @@ func StartHTTPTunnel(config *HTTPTunnelConfig) error {
 	})
 }
 
+// HTTPSTunnelConfig keeps track of HTTPS tunnel configurations (certs, username/passwd, ...)
 type HTTPSTunnelConfig struct {
 	Addr          string
 	ExternalProxy string
@@ -48,6 +66,7 @@ type HTTPSTunnelConfig struct {
 	Password      string
 }
 
+// StartHTTPSTunnel - start HTTPS Tunnel for Edge
 func StartHTTPSTunnel(config *HTTPSTunnelConfig) error {
 	proxy := goproxy.NewProxyHttpServer()
 
@@ -77,7 +96,7 @@ func StartHTTPSTunnel(config *HTTPSTunnelConfig) error {
 			ok := rootCAPool.AppendCertsFromPEM(certs)
 			if !ok {
 				log.Printf("HTTP(S) Tunnel: failed to parse root CA file: %s\n", config.RootCAFile)
-				return errors.New("Failed to parse root CA certificate file.")
+				return errors.New("failed to parse root CA certificate file")
 			}
 
 			proxy.Tr.TLSClientConfig.RootCAs = rootCAPool

--- a/tls/file.go
+++ b/tls/file.go
@@ -1,5 +1,7 @@
 /*
 Copyright (c) 2020, Arm Limited and affiliates.
+Copyright (c) 2023, Izuma Networks
+
 SPDX-License-Identifier: Apache-2.0
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,10 +22,16 @@ import (
 	"io/ioutil"
 )
 
+// FileCertDriverName const for "file"
 const FileCertDriverName = "file"
+
+// FileCertDriverCertKey const for "cert"
 const FileCertDriverCertKey = "cert"
+
+// FileCertDriverKeyKey const for "key"
 const FileCertDriverKeyKey = "key"
 
+// FileCertificateBuilder reads certificates to a certificate chain
 func FileCertificateBuilder(settings CertStrategyConfig) (*tls.Certificate, <-chan *tls.Certificate, error) {
 	certFile, keyFile, err := fileCertificateSettings(settings)
 

--- a/tls/tls.go
+++ b/tls/tls.go
@@ -1,5 +1,7 @@
 /*
 Copyright (c) 2020, Arm Limited and affiliates.
+Copyright (c) 2023, Izuma Networks
+
 SPDX-License-Identifier: Apache-2.0
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,7 +21,10 @@ import (
 	"fmt"
 )
 
+// CertStrategyConfig map / string/string key-value pair storage
 type CertStrategyConfig map[string]string
+
+// CertificateBuilder function prototype
 type CertificateBuilder func(settings CertStrategyConfig) (*tls.Certificate, <-chan *tls.Certificate, error)
 
 var drivers map[string]CertificateBuilder = map[string]CertificateBuilder{
@@ -27,6 +32,7 @@ var drivers map[string]CertificateBuilder = map[string]CertificateBuilder{
 	TpmCertDriverName:  TpmCertificateBuilder,
 }
 
+// MakeCertificate creates certificates with given certificate strategy
 func MakeCertificate(driver string, settings CertStrategyConfig) (*tls.Certificate, <-chan *tls.Certificate, error) {
 	builder, ok := drivers[driver]
 
@@ -37,16 +43,18 @@ func MakeCertificate(driver string, settings CertStrategyConfig) (*tls.Certifica
 	return builder(settings)
 }
 
+// Drivers for certificate builder
 func Drivers() []string {
 	driverNames := make([]string, 0, len(drivers))
 
-	for name, _ := range drivers {
+	for name := range drivers {
 		driverNames = append(driverNames, name)
 	}
 
 	return driverNames
 }
 
+// DefaultDriver returns default cert driver (FileCertDriverName)
 func DefaultDriver() string {
 	return FileCertDriverName
 }

--- a/tls/tpm.go
+++ b/tls/tpm.go
@@ -86,6 +86,7 @@ func generateProtocolName() string {
 	return base64.URLEncoding.EncodeToString(rb)
 }
 
+// TpmCertificateBuilder builds a certificate chain using a TPM
 func TpmCertificateBuilder(settings CertStrategyConfig) (*tls.Certificate, <-chan *tls.Certificate, error) {
 	renewals := make(chan *tls.Certificate)
 


### PR DESCRIPTION
## go vet fix

We have this finding:

```
Running go vet on ./rpc
./client.go:213:3: the cancel function is not used on all paths (possible context leak) ./client.go:245:4: this return statement may be reached without using the cancel var defined on line 213
```

This is due to the cancel being defined, but it's not being called. Golang has the [defer function](https://gobyexample.com/defer) for clean-up tasks, which should be called right after defining it. It will then get automatically call when this function ends (no matter which route).

This cleans `go vet` fully for edge-proxy.

## golint fixes to all files

Fix all the golint findings in this repo. Mostly comments being added.

## Merge golint and go vet jobs in GitHub actions

They are quick jobs, we can run them both in the same job (saves minutes).
