### PR TITLE
Fix misspell findings

### DIFF
--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -279,7 +279,7 @@ func startEdgeProxyReverseTunnel(ca string, proxyURI string, forwardingAddresses
 				fmt.Printf("Edge HTTP proxy server exited\n")
 			}
 
-			fmt.Printf("edge-proxy proxy server shut down. Attemtping to re-launch proxy server in %d seconds...\n", ServerBackoffSeconds)
+			fmt.Printf("edge-proxy proxy server shut down. Attempting to re-launch proxy server in %d seconds...\n", ServerBackoffSeconds)
 			<-time.After(time.Second * ServerBackoffSeconds)
 		}
 	}(certificate)

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -111,7 +111,7 @@ func (c *Client) IsEmpty() bool {
 }
 
 // Call initializes a background context and performs a JSON-RPC call with the given
-// arguments and unmarshals into result if no error occured
+// arguments and unmarshals into result if no error occurred
 //
 // The result must be a pointer so that package json can unmarshal into it. Nil object
 // should not be passed into
@@ -129,7 +129,7 @@ func generateCallID(length int) string {
 }
 
 // CallWithContext performs a JSON-RPC call with the given arguments and unmarshals into
-// result if no error occured
+// result if no error occurred
 func (c *Client) CallWithContext(ctx context.Context, method string, args interface{}, result interface{}) error {
 	id := generateCallID(32)
 

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -1,3 +1,4 @@
+//go:build !unit
 // +build !unit
 
 /*

--- a/tls/tpm.go
+++ b/tls/tpm.go
@@ -78,7 +78,7 @@ type certificate struct {
 	Name string `json:"certificate_name"`
 }
 
-// generateProtocolName generate the name for each JSON-RPC client registered as a protocal translator
+// generateProtocolName generate the name for each JSON-RPC client registered as a protocol translator
 func generateProtocolName() string {
 	rb := make([]byte, 10)
 	rand.Read(rb)
@@ -168,7 +168,7 @@ func configureTLSCert(client *rpc.Client, settings CertStrategyConfig) (tls.Cert
 		return fail(errInvalidECPublicKey)
 	}
 
-	// pass the implementaion of ecdsaPrivateKey as an opaque private key of the cert
+	// pass the implementation of ecdsaPrivateKey as an opaque private key of the cert
 	tlsCert.PrivateKey = &ecdsaPrivateKey{
 		certName:       settings[TpmDeviceCertName],
 		privateKeyName: settings[TpmPrivateKeyName],


### PR DESCRIPTION
Visible in our go report card.

cmd/edge-proxy/main.go
Line 282: warning: "Attemtping" is a misspelling of "Attempting" (misspell) tls/tpm.go
Line 81: warning: "protocal" is a misspelling of "protocol" (misspell) Line 171: warning: "implementaion" is a misspelling of "implementation" (misspell) rpc/client.go
Line 114: warning: "occured" is a misspelling of "occurred" (misspell) Line 132: warning: "occured" is a misspelling of "occurred" (misspell)