### PR TITLE
Add missing shellecheck, move to Sunday

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
   schedule:
     # Once week 02:20 on Saturday
-    - cron: '20 2 * * Sat'
+    - cron: '20 2 * * Sun'
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         run: "scripts-internal/golang/golint_script.sh --all"
       - name: Run pysh-check
         run: |
-           sudo apt-get update && sudo apt-get install -y pycodestyle pydocstyle black
+           sudo apt-get update && sudo apt-get install -y pycodestyle pydocstyle black shellcheck
            echo "." >scripts-internal/.nopyshcheck
            echo "." >vendor/.nopyshcheck
            scripts-internal/pysh-check/pysh-check.sh --workdir .


### PR DESCRIPTION
* Add `shellcheck` installation.
    * It's required. With persistent runners - it can sometimes pass, if an earlier run has installed it...
    * Run failed; https://github.com/PelionIoT/edge-proxy/actions/runs/9815902070/job/27105476094
* Move to Sunday, Saturady is quite loaded already.

Ref: https://izumanetworks.atlassian.net/browse/IZUMABL-527
