### PR TITLE
Advertise HTTP/2 in L4 TLS proxy ALPN for gRPC over NGINX/ENVOY

### DIFF
--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -53,6 +53,7 @@ var externalHTTPProxyCACert string
 var ca string
 var certStrategy string
 var useL4Proxy bool
+var serverName string
 var certStrategyOptions cmd.OptionMap = cmd.OptionMap{}
 var forwardingAddressesMap string
 var httpTunnelAddr string
@@ -71,6 +72,7 @@ func main() {
 	flag.StringVar(&externalHTTPProxyCACert, "extern-http-proxy-cacert", "", "If the external HTTP proxy uses TLS, verify the server certificate against this CA cert, instead of the system root CAs.")
 	flag.BoolVar(&useL4Proxy, "use-l4-proxy", false, "Use a layer 4 proxy instead of a layer 7 proxy")
 	flag.StringVar(&ca, "ca", "", "Certificate authority for the cloud")
+	flag.StringVar(&serverName, "server-name", "", "Server name (SNI) to use when connecting to the cloud, if it differs from the host in proxy-uri. Only applies with use-l4-proxy")
 	flag.StringVar(&certStrategy, "cert-strategy", fog_tls.DefaultDriver(), fmt.Sprintf("Certificate strategy must be one of: %v", fog_tls.Drivers()))
 	flag.Var(&certStrategyOptions, "cert-strategy-options", "Can be specified one or more times. Must be a key-value pair (<key>=<value>)")
 	flag.StringVar(&forwardingAddressesMap, "forwarding-addresses", "{}", "Map of local address to forwarded address for outgoing HTTP requests. For each forwarding request received at proxy-listen, the destination URI in the request is rewritten based on this map, where the destination server is replaced with the value of the corresponding key.  If the destination server isn't found in this map, then the value of proxy-uri is used.  Must be a json string")
@@ -259,7 +261,7 @@ func startEdgeProxyReverseTunnel(ca string, proxyURI string, forwardingAddresses
 
 			if useL4Proxy {
 				fmt.Printf("Starting edge TLS proxy (proxyAddr=%s, proxyURI=%s)\n", proxyAddr, proxyURI)
-				server.RunEdgeTLSProxyServer(childCtx, proxyAddr, proxyURIParsed, caList, cert)
+				server.RunEdgeTLSProxyServer(childCtx, proxyAddr, proxyURIParsed, caList, cert, serverName)
 				fmt.Printf("Edge TLS proxy server exited\n")
 			} else {
 				fmt.Printf("Starting edge HTTP proxy (proxyAddr=%s, proxyURI=%s)\n", proxyAddr, proxyURI)

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -54,6 +54,7 @@ var ca string
 var certStrategy string
 var useL4Proxy bool
 var serverName string
+var disableReverseTunnel bool
 var certStrategyOptions cmd.OptionMap = cmd.OptionMap{}
 var forwardingAddressesMap string
 var httpTunnelAddr string
@@ -66,6 +67,7 @@ var httpsTunnelPassword string
 
 func main() {
 	flag.StringVar(&tunnelURI, "tunnel-uri", "ws://localhost:8181/connect", "Endpoint to connect to for reverse tunneling")
+	flag.BoolVar(&disableReverseTunnel, "disable-reverse-tunnel", false, "Don't establish the reverse tunnel, and serve the outbound proxy only. The tunnel is a websocket (HTTP/1.1), so it can't be used against a cloud endpoint that only accepts HTTP/2")
 	flag.StringVar(&proxyURI, "proxy-uri", "", "Default server to which outgoing HTTP requests should be forwarded.  See forwarding-addresses option for overrides")
 	flag.StringVar(&proxyAddr, "proxy-listen", "0.0.0.0:8080", "Listen address for HTTP proxy server")
 	flag.StringVar(&externalHTTPProxyURI, "extern-http-proxy-uri", "", "optional external Http proxy for site. For an authenticated proxy, specify the username and password in the URI, as in https://user:pwd@proxy-server:proxy-port")
@@ -90,7 +92,7 @@ func main() {
 		proxyOnlyMode = true
 	}
 
-	if tunnelURI == "" {
+	if tunnelURI == "" && !disableReverseTunnel {
 		fmt.Printf("tunnel-uri must be provided\n")
 		os.Exit(1)
 	}
@@ -229,7 +231,16 @@ func startEdgeProxyReverseTunnel(ca string, proxyURI string, forwardingAddresses
 		return err
 	}
 
+	// The reverse tunnel is a websocket, so it speaks HTTP/1.1 over the same proxy
+	// connection the gRPC traffic uses. A cloud endpoint that only accepts HTTP/2
+	// (Envoy with an HTTP2-only listener, for example) closes it immediately, so
+	// allow deployments that only need the outbound proxy to leave it off.
 	go func() {
+		if disableReverseTunnel {
+			fmt.Printf("Reverse tunnel disabled. Running the proxy server only\n")
+			return
+		}
+
 		for {
 			fmt.Printf("Establishing edge-proxy reverse tunnel (tunnelURI=%s)\n", tunnelURI)
 

--- a/server/edge_http_proxy.go
+++ b/server/edge_http_proxy.go
@@ -80,6 +80,9 @@ func RunEdgeTLSProxyServer(ctx context.Context, listenAddr string, cloudURL *url
 		GetClientCertificate: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 			return clientCert, nil
 		},
+		// Advertise HTTP/2 (h2) in TLS ALPN so NGINX negotiates HTTP/2 for gRPC.
+		// Without this, NGINX falls back to HTTP/1.1 and gRPC frames can't be parsed.
+		NextProtos: []string{"h2"},
 	}
 
 	var i uint64

--- a/server/edge_http_proxy.go
+++ b/server/edge_http_proxy.go
@@ -63,8 +63,16 @@ func RunEdgeHTTPProxyServer(ctx context.Context, listenAddr string, forwardingAd
 }
 
 // RunEdgeTLSProxyServer - run TLS proxy server for Edge
-func RunEdgeTLSProxyServer(ctx context.Context, listenAddr string, cloudURL *url.URL, caList *x509.CertPool, clientCert *tls.Certificate) {
+func RunEdgeTLSProxyServer(ctx context.Context, listenAddr string, cloudURL *url.URL, caList *x509.CertPool, clientCert *tls.Certificate, serverName string) {
 	host := host(cloudURL)
+
+	// When the cloud is reached through an address that doesn't match its certificate
+	// (a port-forward or NodePort on 127.0.0.1, for example), serverName overrides the
+	// SNI and verification hostname. Otherwise tls.Dial derives both from host, and the
+	// handshake fails against a certificate issued for the real hostname.
+	if serverName == "" {
+		serverName = cloudURL.Hostname()
+	}
 	listener, err := net.Listen("tcp", listenAddr)
 
 	if err != nil {
@@ -76,7 +84,8 @@ func RunEdgeTLSProxyServer(ctx context.Context, listenAddr string, cloudURL *url
 	defer listener.Close()
 
 	tlsConfig := &tls.Config{
-		RootCAs: caList,
+		RootCAs:    caList,
+		ServerName: serverName,
 		GetClientCertificate: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 			return clientCert, nil
 		},

--- a/server/edge_tls_proxy_test.go
+++ b/server/edge_tls_proxy_test.go
@@ -1,0 +1,192 @@
+//go:build unit
+
+package server
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net"
+	"net/url"
+	"testing"
+	"time"
+)
+
+const upstreamHostname = "stargate.test.local"
+
+// selfSignedForHostname builds a CA-less self-signed cert valid only for
+// upstreamHostname -- one DNS SAN, no IP SANs, mirroring the Let's Encrypt cert
+// Envoy presents in staging.
+func selfSignedForHostname(t *testing.T) (tls.Certificate, *x509.CertPool) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: upstreamHostname},
+		DNSNames:              []string{upstreamHostname},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+
+	pool := x509.NewCertPool()
+	pool.AddCert(leaf)
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+
+	cert, err := tls.X509KeyPair(
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}),
+	)
+	if err != nil {
+		t.Fatalf("keypair: %v", err)
+	}
+
+	return cert, pool
+}
+
+// startEchoUpstream stands in for Envoy: TLS on 127.0.0.1, h2 in ALPN, echoing
+// whatever it receives.
+func startEchoUpstream(t *testing.T, cert tls.Certificate) *url.URL {
+	t.Helper()
+
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		NextProtos:   []string{"h2"},
+	})
+	if err != nil {
+		t.Fatalf("listen upstream: %v", err)
+	}
+
+	t.Cleanup(func() { listener.Close() })
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+
+			go func() {
+				defer conn.Close()
+				io.Copy(conn, conn)
+			}()
+		}
+	}()
+
+	u, err := url.Parse("https://" + listener.Addr().String())
+	if err != nil {
+		t.Fatalf("parse upstream url: %v", err)
+	}
+
+	return u
+}
+
+// runProxy starts the L4 proxy on an ephemeral port and returns its address.
+func runProxy(t *testing.T, upstream *url.URL, pool *x509.CertPool, serverName string) string {
+	t.Helper()
+
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+
+	addr := probe.Addr().String()
+	probe.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	go RunEdgeTLSProxyServer(ctx, addr, upstream, pool, nil, serverName)
+
+	// Give the listener a moment to bind.
+	for i := 0; i < 50; i++ {
+		conn, err := net.Dial("tcp", addr)
+		if err == nil {
+			conn.Close()
+			break
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	return addr
+}
+
+// roundTrip writes a probe payload through the proxy and reports whether it
+// echoed back, which only happens if the upstream TLS handshake succeeded.
+func roundTrip(t *testing.T, proxyAddr string) error {
+	t.Helper()
+
+	conn, err := net.Dial("tcp", proxyAddr)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+
+	defer conn.Close()
+
+	conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	if _, err := conn.Write([]byte("ping")); err != nil {
+		return err
+	}
+
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Without server-name the proxy verifies the upstream cert against the dial
+// address (127.0.0.1), which the hostname-only cert can't satisfy.
+func TestTLSProxyFailsWithoutServerName(t *testing.T) {
+	cert, pool := selfSignedForHostname(t)
+	upstream := startEchoUpstream(t, cert)
+	proxyAddr := runProxy(t, upstream, pool, "")
+
+	if err := roundTrip(t, proxyAddr); err == nil {
+		t.Fatal("expected the upstream handshake to fail against an IP dial address, but traffic flowed")
+	}
+}
+
+// With server-name set, SNI and hostname verification both target the name on
+// the cert, so the handshake completes even though we dialed an IP.
+func TestTLSProxySucceedsWithServerName(t *testing.T) {
+	cert, pool := selfSignedForHostname(t)
+	upstream := startEchoUpstream(t, cert)
+	proxyAddr := runProxy(t, upstream, pool, upstreamHostname)
+
+	if err := roundTrip(t, proxyAddr); err != nil {
+		t.Fatalf("expected traffic to flow with server-name set, got: %v", err)
+	}
+}


### PR DESCRIPTION
Envoy requires h2 ALPN negotiation to proxy gRPC. Without NextProtos on the outbound TLS dial, the connection falls back to HTTP/1.1 and gRPC frames cannot be parsed